### PR TITLE
feat: add karabiner-elements service

### DIFF
--- a/hosts/boris/darwin-configuration.nix
+++ b/hosts/boris/darwin-configuration.nix
@@ -20,7 +20,10 @@
     fontDir = { enable = true; };
     fonts = with pkgs; [ fira-code ];
   };
-  services = { nix-daemon = { enable = true; }; };
+  services = {
+    nix-daemon = { enable = true; };
+    karabiner-elements = { enable = true; };
+  };
   nixpkgs = {
     config = {
       allowUnfree = true;


### PR DESCRIPTION
### Summary

Add karabiner-elements

Also see https://github.com/LnL7/nix-darwin/issues/55 for an alternative for system shortcuts

```nix
{ config, lib, pkgs, ... }:

with lib;

let
  cfg = config.system.keyboard;
in

{
  options = {
    system.keyboard.enableKeyMapping = mkOption {
      type = types.bool;
      default = false;
    };

    system.keyboard.remapAToB = mkOption {
      type = types.bool;
      default = false;
    };

    system.keyboard.userKeyMapping = mkOption {
      type = types.listOf (types.attrsOf types.int);
      default = [];
    };
  };

  config = {

    system.keyboard.enableKeyMapping = mkDefault (cfg.userKeyMapping != []);

    system.keyboard.userKeyMapping = mkMerge [
      (mkIf cfg.remapAToB [{ HIDKeyboardModifierMappingSrc = 30064771076; HIDKeyboardModifierMappingDst = 30064771077; }])
      # ...
    ];

    system.activationScripts.keyboard.text = optionalString cfg.enableKeyMapping ''
      # Configuring keyboard
      echo "remapping keys..." >&2
      hidutil property --set '{"UserKeyMapping":${builtins.toJSON cfg.userKeyMapping}}'
    '';

  };
}
```
